### PR TITLE
fix issue #85: Import orders with none English language stores

### DIFF
--- a/install.xml
+++ b/install.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <modification>
     <name>Knawat Dropshipping</name>
-    <version>1.0.6</version>
+    <version>1.0.11</version>
     <author>Knawat Team</author>
-    <link>https://github.com/Knawat</link>
+    <link>https://github.com/Knawat/knawat-dropshipping-opencart</link>
     <code>knawat_dropshipping_left_menu</code>
     <description>Add Knawat Dropshipping link at left menu</description>
     <file path="admin/controller/common/column_left.php">

--- a/upload/catalog/controller/extension/module/knawat_dropshipping.php
+++ b/upload/catalog/controller/extension/module/knawat_dropshipping.php
@@ -83,8 +83,9 @@ class ControllerExtensionModuleKnawatDropshipping extends Controller {
 		if( $is_update ){
 			$failed = false;
 			$failed_message = 'Something went wrong during order update to Knawat.com';
-			$whilelisted_status = [ 'Pending', 'Processing', 'Cancelled' ];
-			if (!in_array($order_status, $whilelisted_status)) {
+			// Pending, Processing, Cancelled
+			$whilelisted_status = [1,2,7];
+			if (!in_array($order_status_id, $whilelisted_status)) {
                     return false;
                 }
 			try{
@@ -108,8 +109,8 @@ class ControllerExtensionModuleKnawatDropshipping extends Controller {
 		}else{
 			$failed = false;
 			$failed_message = 'Something went wrong during order create on Knawat.com';
-			$push_status = 'Processing';
-			if ($push_status != $order_status) {
+			$push_status = 2; //Processing
+			if ($push_status !== $order_status_id) {
 				return false;
 			}
 			try{


### PR DESCRIPTION
## :memo: Description

fixing the issue #85

### :dart: Relevant issues
issue #85

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a migration update

### :scroll: Steps to test
all steps are mentioned inside the issue #85

