### PR TITLE
Fix: Opencart reject orders with non-English status #85

### DIFF
--- a/upload/admin/controller/extension/module/knawat_dropshipping.php
+++ b/upload/admin/controller/extension/module/knawat_dropshipping.php
@@ -172,6 +172,10 @@ class ControllerExtensionModuleKnawatDropshipping extends Controller {
 			'consumer_key_placeholder' 		=> $this->language->get('consumer_key_placeholder'),
 			'entry_consumer_secret' 		=> $this->language->get('entry_consumer_secret'),
 			'consumer_secret_placeholder' 	=> $this->language->get('consumer_secret_placeholder'),
+			'entry_orders_statuses' 		=> $this->language->get('entry_orders_statuses'),
+			'entry_order_pending_status' 	=> $this->language->get('entry_order_pending_status'),
+			'entry_order_processing_status' => $this->language->get('entry_order_processing_status'),
+			'entry_order_cancelled_status' 	=> $this->language->get('entry_order_cancelled_status'),
 		);
 
 		// Check and set warning.
@@ -267,6 +271,21 @@ class ControllerExtensionModuleKnawatDropshipping extends Controller {
 			$data['module_knawat_dropshipping_consumer_secret'] = $this->config->get('module_knawat_dropshipping_consumer_secret');
 		}
 
+		// Order statuses mapping
+		$this->load->model('localisation/order_status');
+
+		$data['order_statuses'] = $this->model_localisation_order_status->getOrderStatuses();
+		// Use default statuses for first time 
+		$data['module_knawat_dropshipping_order_pending'] = $this->config->get('module_knawat_dropshipping_order_pending')?:$this->default_order_status_id($data['order_statuses'],'Pending');
+		$data['module_knawat_dropshipping_order_processing'] = $this->config->get('module_knawat_dropshipping_order_processing')?:$this->default_order_status_id($data['order_statuses'],'Processing');
+		$data['module_knawat_dropshipping_order_cancelled'] = $this->config->get('module_knawat_dropshipping_order_cancelled')?:$this->default_order_status_id($data['order_statuses'],'Canceled');
+		
+		if(isset($this->request->post['module_knawat_dropshipping_order_processing'])){
+			$data['module_knawat_dropshipping_order_pending'] = $this->request->post['module_knawat_dropshipping_order_pending'];
+			$data['module_knawat_dropshipping_order_processing'] = $this->request->post['module_knawat_dropshipping_order_processing'];
+			$data['module_knawat_dropshipping_order_cancelled'] = $this->request->post['module_knawat_dropshipping_order_cancelled'];
+		}
+
 		// Setup Stores.
 		$this->load->model('setting/store');
 		$data['stores'] = array();
@@ -349,6 +368,14 @@ class ControllerExtensionModuleKnawatDropshipping extends Controller {
 		$data['footer'] = $this->load->controller('common/footer');
 
 		$this->response->setOutput($this->load->view( $this->route, $data) );
+	}
+
+	private function default_order_status_id($list,$status){
+		$index = array_search($status, array_column($list, 'name'));
+		if($index){
+			return $list[$index]['order_status_id'];
+		}
+		return null;
 	}
 
 	protected function validate() {

--- a/upload/admin/language/ar/extension/module/knawat_dropshipping.php
+++ b/upload/admin/language/ar/extension/module/knawat_dropshipping.php
@@ -40,6 +40,10 @@ $_['entry_consumer_key']     		= 'رقم العميل الخاص بقنوات';
 $_['consumer_key_placeholder']		= 'ادخل رقم العميل الخاص بقنوات';
 $_['entry_consumer_secret'] 		= 'الرقم السري الخاص بقنوات';
 $_['consumer_secret_placeholder']	= 'ادخل الرقم السري الخاص بقنوات';
+$_['entry_orders_statuses']	        = 'حالات الطلب';
+$_['entry_order_pending_status']	= 'معلق';
+$_['entry_order_processing_status']	= 'قيد التنفيذ';
+$_['entry_order_cancelled_status']	= 'ملغي';
 $_['entry_store']         			= 'استيراد المنتجات لهذه المتاجر';
 $_['entry_connection']              = 'وضع الاتصال';
 

--- a/upload/admin/language/en-gb/extension/module/knawat_dropshipping.php
+++ b/upload/admin/language/en-gb/extension/module/knawat_dropshipping.php
@@ -39,6 +39,10 @@ $_['entry_consumer_key']     		= 'Knawat Consumer Key';
 $_['consumer_key_placeholder']		= 'Enter Knawat Consumer Key';
 $_['entry_consumer_secret'] 		= 'Knawat Consumer Secret';
 $_['consumer_secret_placeholder']	= 'Enter Knawat Consumer Secret';
+$_['entry_orders_statuses']	        = 'Order Statuses';
+$_['entry_order_pending_status']	= 'Pending';
+$_['entry_order_processing_status']	= 'Processing';
+$_['entry_order_cancelled_status']	= 'Cancelled';
 $_['entry_store']         			= 'Import Products into these Stores';
 $_['entry_connection']              = 'Connection Status';
 

--- a/upload/admin/view/template/extension/module/knawat_dropshipping.twig
+++ b/upload/admin/view/template/extension/module/knawat_dropshipping.twig
@@ -109,6 +109,60 @@
                         </div>
                     </div>
 
+
+                     <div class="form-group">
+                       <label class="col-sm-2" for="">{{ entry_orders_statuses }}</label>
+                       <div class="col-sm-10">
+                            <div class="form-group">
+                                <label class="col-sm-2 control-label" for="input-order-pending-status">{{ entry_order_pending_status }}</label>
+                                <div class="col-sm-10">
+                                    <select name="module_knawat_dropshipping_order_pending" id="input-order-pending-status" class="form-control">
+                                    {% for order_status in order_statuses %}
+                                    {% if order_status.order_status_id == module_knawat_dropshipping_order_pending %}
+                                    <option value="{{ order_status.order_status_id }}" selected="selected">{{ order_status.name }}</option>
+                                    {% else %}
+                                    <option value="{{ order_status.order_status_id }}">{{ order_status.name }}</option>
+                                    {% endif %}
+                                    {% endfor %}
+                                    </select>
+                                   
+                                </div>
+                            </div>
+
+
+                            <div class="form-group">
+                                <label class="col-sm-2 control-label" for="input-order-processing-status">{{ entry_order_processing_status }}</label>
+                                <div class="col-sm-10">
+                                    <select name="module_knawat_dropshipping_order_processing" id="input-order-processing-status" class="form-control">
+                                    {% for order_status in order_statuses %}
+                                    {% if order_status.order_status_id == module_knawat_dropshipping_order_processing %}
+                                    <option value="{{ order_status.order_status_id }}" selected="selected">{{ order_status.name }}</option>
+                                    {% else %}
+                                    <option value="{{ order_status.order_status_id }}">{{ order_status.name }}</option>
+                                    {% endif %}
+                                    {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                            
+                            <div class="form-group">
+                                <label class="col-sm-2 control-label" for="input-order-cancelled-status">{{ entry_order_cancelled_status }}</label>
+                                <div class="col-sm-10">
+                                    <select name="module_knawat_dropshipping_order_cancelled" id="input-order-cancelled-status" class="form-control">
+                                    {% for order_status in order_statuses %}
+                                    {% if order_status.order_status_id == module_knawat_dropshipping_order_cancelled %}
+                                    <option value="{{ order_status.order_status_id }}" selected="selected">{{ order_status.name }}</option>
+                                    {% else %}
+                                    <option value="{{ order_status.order_status_id }}">{{ order_status.name }}</option>
+                                    {% endif %}
+                                    {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                       </div>
+
+                     </div>
+                  
                     <div class="form-group">
                         <label class="col-sm-2 control-label">{{ entry_store }}</label>
                         <div class="col-sm-10">

--- a/upload/system/library/knawat_dropshipping/knawatmpapi.php
+++ b/upload/system/library/knawat_dropshipping/knawatmpapi.php
@@ -301,7 +301,6 @@
 
         // Execute the request and decode the response to JSON
         $resource_data = json_decode( curl_exec( $this->ch ) );
-        //print_r(  $resource_data );
 
         // Retrieve the HTTP response code
         $response_code = (int) curl_getinfo( $this->ch, CURLINFO_HTTP_CODE );
@@ -328,7 +327,7 @@
             return array( 
                 $resource_data, 
                 $curl_request_url,
-                $request_form_data,
+                $data,
                 $response_data,
                 $curl_info
             ); 


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->
fix issue: #85  
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a migration update

### :scroll: Steps to test
- download these PR files 
- install it as an extension in opencart 
- enable the Arabic language to your opencart
- change the order status name of processing to 'جاري التنفيذ' or anything in Arabic from localization section
- save settings in the knawat dropshipping plugin 
- make an order and from admin panel update the status to 'جاري التنفيذ'
- Now you can see the order in your knawat dashboard

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


